### PR TITLE
Make PIN entry optional

### DIFF
--- a/Dialer/Dialer.xcodeproj/project.pbxproj
+++ b/Dialer/Dialer.xcodeproj/project.pbxproj
@@ -109,6 +109,7 @@
 		CBE3D8AE290C1D6500DF5C09 /* DialerQuickCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB45381128AB8FE000F3F24C /* DialerQuickCode.swift */; };
 		CBE73C5E2A2C76BF00C7712B /* MockPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE73C5D2A2C76BF00C7712B /* MockPreview.swift */; };
 		CBE73C612A2C789C00C7712B /* ContactRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE73C602A2C789C00C7712B /* ContactRowView.swift */; };
+		F4EE6CE82A6531D800F7EEDA /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EE6CE72A6531D800F7EEDA /* AppConstants.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -222,6 +223,7 @@
 		CBE3D8AB290C168400DF5C09 /* DialerQuickCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DialerQuickCodeTests.swift; sourceTree = "<group>"; };
 		CBE73C5D2A2C76BF00C7712B /* MockPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPreview.swift; sourceTree = "<group>"; };
 		CBE73C602A2C789C00C7712B /* ContactRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactRowView.swift; sourceTree = "<group>"; };
+		F4EE6CE72A6531D800F7EEDA /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -407,6 +409,7 @@
 				CB18BD4229AE0C0800A7B45C /* ForceUpdateManager.swift */,
 				CB18BD4429AE0C3200A7B45C /* FirebaseRemoteConfig.swift */,
 				CB338CDB29AF6BDC00BEAD9A /* AppConfiguration.swift */,
+				F4EE6CE72A6531D800F7EEDA /* AppConstants.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -749,6 +752,7 @@
 				CB1B8EC729014C8A00DFBCDB /* AlertDialog.swift in Sources */,
 				CB18BD5329AE915000A7B45C /* MerchantViewModel.swift in Sources */,
 				825F996326720AE6009E4A7B /* TransferView.swift in Sources */,
+				F4EE6CE82A6531D800F7EEDA /* AppConstants.swift in Sources */,
 				CB45381028AB7E8B00F3F24C /* USSDCode.swift in Sources */,
 				CBA9BB03294C8F4900D95C82 /* AppNotification.swift in Sources */,
 				CB338CD829AF668300BEAD9A /* FirebaseTracker+Extensions.swift in Sources */,

--- a/Dialer/Dialer/Models/PurchaseDetailModel.swift
+++ b/Dialer/Dialer/Models/PurchaseDetailModel.swift
@@ -15,11 +15,12 @@ struct PurchaseDetailModel: Hashable, Codable {
     private var prefixCode: String { "*182*2*1*1*1*" }
 
     func getDialCode(pin: String) -> String {
-        /// `27/03/2023`: MTN disabled the ability to dial airtime USSD that includes Momo PIN for an amount greater than 100.
-        if amount > 100 || pin.isEmpty {
-            return "\(prefixCode)\(amount)#"
-        } else {
+        /// `27/03/2023`: MTN disabled the ability to dial airtime USSD that includes Momo PIN for an amount greater than 99.
+        /// You can dial the code with PIN for amount in the range of 10 to 99
+        if AppConstants.allowedAmountRangeForPin.contains(amount) && !pin.isEmpty {
             return "\(prefixCode)\(amount)*\(pin)#"
+        } else {
+            return "\(prefixCode)\(amount)#"
         }
     }
 }

--- a/Dialer/Dialer/Utilities/AppConstants.swift
+++ b/Dialer/Dialer/Utilities/AppConstants.swift
@@ -9,6 +9,7 @@ import Foundation
 
 struct AppConstants {
     // Airtime USSD Dial constants
+    private init() { }
     static let minAmount = 1
     static let allowedAmountRangeForPin = 10..<100
 }

--- a/Dialer/Dialer/Utilities/AppConstants.swift
+++ b/Dialer/Dialer/Utilities/AppConstants.swift
@@ -1,0 +1,14 @@
+//
+//  AppConstants.swift
+//  Dialer
+//
+//  Created by Nicolas Nshuti on 17/07/2023.
+//
+
+import Foundation
+
+struct AppConstants {
+    // Airtime USSD Dial constants
+    static let minAmount = 1
+    static let allowedAmountRangeForPin = 10..<100
+}

--- a/Dialer/Dialer/View Models/MainViewModel.swift
+++ b/Dialer/Dialer/View Models/MainViewModel.swift
@@ -348,11 +348,11 @@ extension RecentDialCode {
 
 // MARK: - Extension for `PurchaseDetailView` methods
 extension MainViewModel {
-    var validAmount: Bool {
+    var hasValidAmount: Bool {
         purchaseDetail.amount >= AppConstants.minAmount
     }
     
-    var validCode: Bool {
+    var isPinCodeValid: Bool {
         if let pinCode {
             return String(pinCode).count == 5
         }

--- a/Dialer/Dialer/View Models/MainViewModel.swift
+++ b/Dialer/Dialer/View Models/MainViewModel.swift
@@ -145,7 +145,6 @@ protocol UtilitiesDelegate {
             code = ""
         }
         return purchase.getDialCode(pin: code)
-
     }
 
     func getPurchaseDetailUSSDCode() -> String {
@@ -344,5 +343,19 @@ extension RecentDialCode {
          back when a quick action is triggered.
          */
         return [ SceneDelegate.codeIdentifierInfoKey: self.id.uuidString as NSSecureCoding ]
+    }
+}
+
+// MARK: - Extension for `PurchaseDetailView` methods
+extension MainViewModel {
+    var validAmount: Bool {
+        purchaseDetail.amount >= AppConstants.minAmount
+    }
+    
+    var validCode: Bool {
+        if let pinCode {
+            return String(pinCode).count == 5
+        }
+        return false
     }
 }

--- a/Dialer/Dialer/Views/Main/PurchaseDetailView.swift
+++ b/Dialer/Dialer/Views/Main/PurchaseDetailView.swift
@@ -36,8 +36,8 @@ struct PurchaseDetailView: View {
             
             VStack(spacing: 10) {
                 
-                Text(data.validAmount ? data.purchaseDetail.amount.description : NSLocalizedString("Enter Amount", comment: ""))
-                    .opacity(data.validAmount ? 1 : 0.6)
+                Text(data.hasValidAmount ? data.purchaseDetail.amount.description : NSLocalizedString("Enter Amount", comment: ""))
+                    .opacity(data.hasValidAmount ? 1 : 0.6)
                     .frame(maxWidth: .infinity)
                     .frame(height: 40)
                     .background(Color.primary.opacity(0.06))
@@ -101,8 +101,8 @@ struct PurchaseDetailView: View {
                                     .cornerRadius(8)
                                     .foregroundColor(Color(.systemBackground))
                             }
-                                .disabled(!data.validCode)
-                                .opacity(data.validCode ? 1 : 0.4)
+                                .disabled(!data.isPinCodeValid)
+                                .opacity(data.isPinCodeValid ? 1 : 0.4)
                             , alignment: .trailing
                         )
                         
@@ -127,11 +127,11 @@ struct PurchaseDetailView: View {
                         Text("Confirm")
                             .frame(maxWidth: .infinity)
                             .frame(height: 45)
-                            .background(Color.blue.opacity((!data.validAmount) ? 0.5 : 1))
+                            .background(Color.blue.opacity((!data.hasValidAmount) ? 0.5 : 1))
                             .cornerRadius(8)
                             .foregroundColor(.white)
                     }
-                    .disabled(!data.validAmount)
+                    .disabled(!data.hasValidAmount)
                 } else {
                     VStack(spacing: 6) {
                         Button(action: {
@@ -141,11 +141,11 @@ struct PurchaseDetailView: View {
                             Label("Copy USSD code", systemImage: "doc.on.doc.fill")
                                 .frame(maxWidth: .infinity)
                                 .frame(height: 45)
-                                .background(Color.primary.opacity((!data.validAmount) ? 0.5 : 1))
+                                .background(Color.primary.opacity((!data.hasValidAmount) ? 0.5 : 1))
                                 .cornerRadius(8)
                                 .foregroundColor(Color(.systemBackground))
                         }
-                        .disabled(!data.validAmount)
+                        .disabled(!data.hasValidAmount)
                         if didCopyToClipBoard {
                             CopiedUSSDLabel()
                         }

--- a/Dialer/Dialer/Views/Main/PurchaseDetailView.swift
+++ b/Dialer/Dialer/Views/Main/PurchaseDetailView.swift
@@ -14,17 +14,6 @@ struct PurchaseDetailView: View {
     @State private var codepin: String = ""
     @State private var didCopyToClipBoard: Bool = false
     
-    private var validCode: Bool {
-        if let pin = data.pinCode {
-            return String(pin).count == 5
-        }
-        return false
-    }
-    
-    private var validAmount: Bool {
-        data.purchaseDetail.amount > 0
-    }
-    
     @State var show = false
     @State var bottomState = CGSize.zero
     @State var showFull = false
@@ -47,8 +36,8 @@ struct PurchaseDetailView: View {
             
             VStack(spacing: 10) {
                 
-                Text(validAmount ? data.purchaseDetail.amount.description : NSLocalizedString("Enter Amount", comment: ""))
-                    .opacity(validAmount ? 1 : 0.6)
+                Text(data.validAmount ? data.purchaseDetail.amount.description : NSLocalizedString("Enter Amount", comment: ""))
+                    .opacity(data.validAmount ? 1 : 0.6)
                     .frame(maxWidth: .infinity)
                     .frame(height: 40)
                     .background(Color.primary.opacity(0.06))
@@ -112,8 +101,8 @@ struct PurchaseDetailView: View {
                                     .cornerRadius(8)
                                     .foregroundColor(Color(.systemBackground))
                             }
-                                .disabled(!validCode)
-                                .opacity(validCode ? 1 : 0.4)
+                                .disabled(!data.validCode)
+                                .opacity(data.validCode ? 1 : 0.4)
                             , alignment: .trailing
                         )
                         
@@ -138,11 +127,11 @@ struct PurchaseDetailView: View {
                         Text("Confirm")
                             .frame(maxWidth: .infinity)
                             .frame(height: 45)
-                            .background(Color.blue.opacity((!validCode || !validAmount) ? 0.5 : 1))
+                            .background(Color.blue.opacity((!data.validAmount) ? 0.5 : 1))
                             .cornerRadius(8)
                             .foregroundColor(.white)
                     }
-                    .disabled(!validCode || !validAmount)
+                    .disabled(!data.validAmount)
                 } else {
                     VStack(spacing: 6) {
                         Button(action: {
@@ -152,11 +141,11 @@ struct PurchaseDetailView: View {
                             Label("Copy USSD code", systemImage: "doc.on.doc.fill")
                                 .frame(maxWidth: .infinity)
                                 .frame(height: 45)
-                                .background(Color.primary.opacity((!validCode || !validAmount) ? 0.5 : 1))
+                                .background(Color.primary.opacity((!data.validAmount) ? 0.5 : 1))
                                 .cornerRadius(8)
                                 .foregroundColor(Color(.systemBackground))
                         }
-                        .disabled(!validCode || !validAmount)
+                        .disabled(!data.validAmount)
                         if didCopyToClipBoard {
                             CopiedUSSDLabel()
                         }

--- a/Dialer/DialerTests/Test Cases/ModelTests/PurchaseDetailModelTests.swift
+++ b/Dialer/DialerTests/Test Cases/ModelTests/PurchaseDetailModelTests.swift
@@ -20,8 +20,8 @@ final class PurchaseDetailModelTests: XCTestCase {
 
     func testUSSDCodesSuit()  throws {
         try testPinLessPurchase()
-        try testPinnedPurchaseSmallAmount()
-        try testPinnedPurchaseBigAmount()
+        try testPinnedPurchase_amountOutOfRangeForPinAppending()
+        try testPinnedPurchase_amountInRangeForPinAppending()
     }
 
     func testPinLessPurchase() throws {
@@ -32,22 +32,22 @@ final class PurchaseDetailModelTests: XCTestCase {
 
     }
 
-    func testPinnedPurchaseSmallAmount() throws {
+    func testPinnedPurchase_amountOutOfRangeForPinAppending() throws {
         let pin = 22000
         let purchase = PurchaseDetailModel(amount: 100)
 
-        let expectedPinnedCode = "*182*2*1*1*1*100*\(pin)#"
-        XCTAssertEqual(expectedPinnedCode, purchase.getDialCode(pin: "\(pin)"))
+        let expectedPinnedCode = "*182*2*1*1*1*100#"
+        XCTAssertEqual(expectedPinnedCode, purchase.getDialCode(pin: "\(pin)"), "For the range of 10 to 99, pin should not be appended to the string")
     }
     
-    func testPinnedPurchaseBigAmount() throws {
+    func testPinnedPurchase_amountInRangeForPinAppending() throws {
         let pin = 22000
-        let purchase = PurchaseDetailModel(amount: 1000)
+        let amount = 50
+        let purchase = PurchaseDetailModel(amount: amount)
 
-        let expectedPinnedCode = "*182*2*1*1*1*1000#"
-        XCTAssertEqual(expectedPinnedCode, purchase.getDialCode(pin: String(pin)))
+        let expectedPinnedCode = "*182*2*1*1*1*\(amount)*\(pin)#"
+        XCTAssertEqual(expectedPinnedCode, purchase.getDialCode(pin: "\(pin)"), "For the range of 10 to 99, the pin is appended to the string")
     }
-
 
     func testPerformanceExample() throws {
         // This is an example of a performance test case.

--- a/Dialer/DialerTests/Test Cases/ModelTests/PurchaseDetailModelTests.swift
+++ b/Dialer/DialerTests/Test Cases/ModelTests/PurchaseDetailModelTests.swift
@@ -20,8 +20,8 @@ final class PurchaseDetailModelTests: XCTestCase {
 
     func testUSSDCodesSuit()  throws {
         try testPinLessPurchase()
-        try testPinnedPurchase_amountOutOfRangeForPinAppending()
-        try testPinnedPurchase_amountInRangeForPinAppending()
+        try testPinnedPurchaseAmountOutOfRangeForPinAppending()
+        try testPinnedPurchaseAmountInRangeForPinAppending()
     }
 
     func testPinLessPurchase() throws {
@@ -32,7 +32,7 @@ final class PurchaseDetailModelTests: XCTestCase {
 
     }
 
-    func testPinnedPurchase_amountOutOfRangeForPinAppending() throws {
+    func testPinnedPurchaseAmountOutOfRangeForPinAppending() throws {
         let pin = 22000
         let purchase = PurchaseDetailModel(amount: 100)
 
@@ -40,7 +40,7 @@ final class PurchaseDetailModelTests: XCTestCase {
         XCTAssertEqual(expectedPinnedCode, purchase.getDialCode(pin: "\(pin)"), "For the range of 10 to 99, pin should not be appended to the string")
     }
     
-    func testPinnedPurchase_amountInRangeForPinAppending() throws {
+    func testPinnedPurchaseAmountInRangeForPinAppending() throws {
         let pin = 22000
         let amount = 50
         let purchase = PurchaseDetailModel(amount: amount)


### PR DESCRIPTION
## Description

Currently MTN does not support PIN to be appended to the USSD string for mount equal or greater than 100 when purchasing airtime but Dialer still requires the PIN.

## The Fix
This PR:
- Makes the PIN entry optional for airtime purchase.
- Adds a new file `AppConstants` to use for all app constants
- Updates unit tests
